### PR TITLE
Redirect webpack dev server requests to index.html

### DIFF
--- a/webpack.config.dev.js
+++ b/webpack.config.dev.js
@@ -14,6 +14,7 @@ module.exports = {
   output: {
     path: path.resolve(__dirname + '/dist'),
     filename: '[name].js',
+    publicPath: '/',
   },
 
   plugins: [
@@ -62,6 +63,8 @@ module.exports = {
   },
 
   devServer: {
+    // Redirect 404s to index.html
+    historyApiFallback: true,
     inline: true,
     stats: { colors: true },
   },


### PR DESCRIPTION
Fixes #14

## Description

- Not disabling back. We won't allow it to change game state.
- Webpack dev server can handle loading other than site root
