### PR TITLE
add team notification to PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,5 +2,7 @@ Fixes #
 
 ## Description
 
-- 
 -
+-
+
+@TheLabCollective/developers


### PR DESCRIPTION
Fixes #3 more

## Description

- Since we can't have multiple reviewers requested, set a notification in the PR template to let them know, like this:

@TheLabCollective/developers 