### PR TITLE
Feature/161 add optional image to emails

### DIFF
--- a/src/Content.elm
+++ b/src/Content.elm
@@ -1,4 +1,4 @@
-module Content exposing (BranchingContent(..), Datastore, DocumentData, EmailData, MessageData, SocialData, datastoreDictDecoder, emptyEmail, emptyMessage, emptyDocument)
+module Content exposing (BranchingContent(..), Datastore, DocumentData, EmailData, ImageData, MessageData, SocialData, datastoreDictDecoder, emptyEmail, emptyMessage, emptyDocument)
 
 import Dict exposing (Dict)
 import Json.Decode exposing (field, list, int, map4, maybe, string)
@@ -49,6 +49,7 @@ type alias EmailData =
     , subject : String
     , preview : String
     , content : String
+    , image : Maybe ImageData
     , basename : String
     , choices : Maybe (List String)
     , scoreChangeEconomic : Maybe (List String)
@@ -96,6 +97,7 @@ emptyEmail =
     , subject = ""
     , choices = Nothing
     , preview = ""
+    , image = Nothing
     , content = "Sorry. Something's gone wrong."
     , basename = ""
     , scoreChangeEconomic = Nothing
@@ -188,6 +190,7 @@ emailDictDecoder =
             |> andMap (Json.Decode.field "subject" string |> withDefault "")
             |> andMap (Json.Decode.field "preview" string |> withDefault "")
             |> andMap (Json.Decode.field "content" string |> withDefault "")
+            |> andMap (Json.Decode.maybe (Json.Decode.field "image" imageDecoder))
             |> andMap (Json.Decode.field "basename" string |> withDefault "")
             |> andMap (Json.Decode.maybe (Json.Decode.field "choices" (list string)))
             |> andMap (Json.Decode.maybe (Json.Decode.field "scoreChangeEconomic" (list string)))
@@ -203,7 +206,7 @@ socialDictDecoder =
             |> andMap (Json.Decode.field "triggered_by" (list string) |> withDefault [])
             |> andMap (Json.Decode.field "author" string |> withDefault "")
             |> andMap (Json.Decode.field "handle" string |> withDefault "")
-            |> andMap (Json.Decode.maybe imageDecoder)
+            |> andMap (Json.Decode.maybe (Json.Decode.field "image" imageDecoder))
             |> andMap (Json.Decode.field "content" string |> withDefault "")
             |> andMap (Json.Decode.field "basename" string |> withDefault "")
             |> andMap (Json.Decode.field "numComments" int |> withDefault 0)

--- a/src/View/Emails.elm
+++ b/src/View/Emails.elm
@@ -25,6 +25,7 @@ type alias EmailWithRead =
     , subject : String
     , preview : String
     , content : String
+    , image : Maybe Content.ImageData
     , basename : String
     , read : Bool
     }
@@ -56,6 +57,7 @@ single gamedata maybeContent =
                     , div [ class "ml-3" ] [ text email.author ]
                     ]
                 , div [ class "mt-3" ] [ Markdown.toHtml [ class "content" ] email.content ]
+                , renderImage email
                 , if List.length choiceList > 0 then
                     div [ class "button-choices" ]
                         (div [ class "quick-reply" ] [ text (t EmailQuickReply) ]
@@ -92,6 +94,7 @@ addReadStatus emailData visitedSet =
             , subject = email.subject
             , preview = email.preview
             , content = email.content
+            , image = email.image
             , basename = email.basename
             , read = readStatus
             }
@@ -114,6 +117,14 @@ listItem email =
                 ]
             ]
         ]
+
+renderImage : Content.EmailData -> Html Msg
+renderImage email =
+  case email.image of
+    Nothing ->
+      text ""
+    Just image ->
+      img [src (image.src), alt (image.alt) ][]
 
 
 generateCssString : String.String -> String.String


### PR DESCRIPTION
Fixes #161

## Description

- Depends on #115 with social image implementation for CMS
- Add optional unstyled image to emails

@TheLabCollective/developers
