### PR TITLE
Check email for choices before flagging as needs reply

### DIFF
--- a/src/GameData.elm
+++ b/src/GameData.elm
@@ -256,6 +256,9 @@ emailContainsPendingDecision email choices =
                 Nothing ->
                     []
 
+        hasChoices =
+            List.length potentialChoices > 0
+
         triggerString =
             String.join "|" (List.reverse choices)
 
@@ -265,7 +268,7 @@ emailContainsPendingDecision email choices =
         hasChoiceMatchLastChoice =
             List.member ("|" ++ Maybe.withDefault "" (List.head choices)) potentialChoices
     in
-    triggeredByLastChoice && not hasChoiceMatchLastChoice
+    hasChoices && triggeredByLastChoice && not hasChoiceMatchLastChoice
 
 
 


### PR DESCRIPTION
Fixes #193 

## Description

- Only flag as needs reply if email contains choices
-

@TheLabCollective/developers
