### PR TITLE
fix low colour contrast

### DIFF
--- a/src/styles/app.scss
+++ b/src/styles/app.scss
@@ -2,7 +2,7 @@
 :root {
   --red: #dc3545;
   --green: #28a745;
-  --blue: #007bff;
+  --blue: #0072ed;
   --blue-pale: #9fb8f0;
   --purple: #563d7c;
   --white: #ffffff;
@@ -49,6 +49,10 @@ body {
       svg {
         color: var(--white);
       }
+    }
+
+    &.active {
+      font-weight: bold;
     }
   }
 }


### PR DESCRIPTION
Part of  #156

## Description

- Not a big change, but Bootstrap Blue causes a contrast fail

![image](https://user-images.githubusercontent.com/32434620/112803825-9d4e8000-906b-11eb-83e9-f1fef90e9254.png)


@TheLabCollective/developers
