### PR TITLE
fix document read labels

### DIFF
--- a/src/View/Documents.elm
+++ b/src/View/Documents.elm
@@ -166,7 +166,7 @@ listItem : DocumentWithRead -> Html Msg
 listItem content =
     div [ class "col-6 col-lg-4" ]
         [ a [ class "card", href (Route.toString (Document content.basename)) ]
-            [ div [ classList [ ( "read", content.read ) ] ]
+            [ div [ classList [ ( "doc-read", content.read ) ] ]
                 [ span [ class "badge new" ] [ text (t New) ]
                 , renderCardImage content
                 , h2 [ class "card-title" ] [ text content.title ]

--- a/src/styles/document.scss
+++ b/src/styles/document.scss
@@ -103,7 +103,7 @@
   z-index: 1;
 }
 
-.card.read {
+.doc-read {
   .new {
     display: none;
   }
@@ -112,4 +112,14 @@
 .card-icon {
   width: 100%;
   filter: drop-shadow(0px 0px 5px var(--black));
+}
+
+@media (min-width: 767px) {
+  .documents .card {
+    margin: 0 2rem 2rem 2rem;
+  }
+
+  .documents .card-title {
+    font-size: 1.2rem;
+  }
 }


### PR DESCRIPTION
Fixes #214 

## Description

- CSS was dependent on different nesting

@TheLabCollective/developers
