### PR TITLE
Rename feedback close button

### DIFF
--- a/src/Copy/Text.elm
+++ b/src/Copy/Text.elm
@@ -167,7 +167,7 @@ t key =
             "https://incidentallyb.typeform.com/to/WEEJSvQN"
 
         FeedbackFormClose ->
-            "No, thanks"
+            "Close"
 
         SubmitEndChoices ->
             "Submit choices"


### PR DESCRIPTION
After #164 

## Description

- rename modal close button so it makes sense in context after user has answered
-

@TheLabCollective/developers
